### PR TITLE
Fix GitHub Actions artifact deprecation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/configure-pages@v3
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: '.'
   deploy:


### PR DESCRIPTION
## Summary
- update `actions/upload-pages-artifact` to v3 so that `upload-artifact` v4 is used

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68667608ca68832495847598bba4180d