### PR TITLE
Implement multi-page dart game UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,44 @@
 (function() {
-  const gameSection = document.getElementById('game');
-  const scoreboard = document.getElementById('scoreboard');
-  const startBtn = document.getElementById('start-game');
-  const modeSelect = document.getElementById('mode');
-  const playersInput = document.getElementById('players');
-  const doubleOutCheckbox = document.getElementById('double-out');
+  const sections = {
+    home: document.getElementById('home'),
+    newGame: document.getElementById('new-game'),
+    game: document.getElementById('game'),
+    stats: document.getElementById('stats'),
+    players: document.getElementById('players'),
+    rules: document.getElementById('rules')
+  };
+
+  function showSection(id) {
+    Object.values(sections).forEach(s => s.classList.add('hidden'));
+    sections[id].classList.remove('hidden');
+  }
+
+  document.getElementById('btn-new-game').addEventListener('click', () => showSection('newGame'));
+  document.getElementById('btn-stats').addEventListener('click', () => { loadStats(); showSection('stats'); });
+  document.getElementById('btn-players').addEventListener('click', () => { loadPlayers(); showSection('players'); });
+  document.getElementById('btn-rules').addEventListener('click', () => showSection('rules'));
+
+  document.getElementById('back-home-from-new').addEventListener('click', () => showSection('home'));
+  document.getElementById('back-home-from-game').addEventListener('click', () => showSection('home'));
+  document.getElementById('back-home-from-stats').addEventListener('click', () => showSection('home'));
+  document.getElementById('back-home-from-players').addEventListener('click', () => showSection('home'));
+  document.getElementById('back-home-from-rules').addEventListener('click', () => showSection('home'));
+
   const rulesText = document.getElementById('rules-text');
+  const modeSelect = document.getElementById('mode');
+  const roundsInput = document.getElementById('rounds');
+  const doubleIn = document.getElementById('double-in');
+  const doubleOut = document.getElementById('double-out');
+  const playersInput = document.getElementById('players');
+  const startBtn = document.getElementById('start-game');
+  const addGuestBtn = document.getElementById('add-guest');
+  const scoreboard = document.getElementById('scoreboard');
+  const throwArea = document.getElementById('throw-area');
+  const nextPlayerBtn = document.getElementById('next-player');
   const statsContent = document.getElementById('stats-content');
+  const playersList = document.getElementById('players-list');
+  const newPlayerInput = document.getElementById('new-player');
+  const addPlayerBtn = document.getElementById('add-player');
 
   const rules = {
     '301': 'Jeder Spieler startet bei 301 Punkten und spielt herunter.',
@@ -14,17 +46,126 @@
     'tannenbaum': 'Treffe der Reihe nach die Felder 1 bis 20 und dann die Doppel.'
   };
 
-  // Update rules when mode changes
   modeSelect.addEventListener('change', () => {
     rulesText.textContent = rules[modeSelect.value] || '';
   });
+
+  function loadPlayers() {
+    const data = JSON.parse(localStorage.getItem('darts-players') || '[]');
+    playersList.innerHTML = data.map(n => `<div>${n}</div>`).join('');
+  }
+
+  function savePlayer(name) {
+    const data = JSON.parse(localStorage.getItem('darts-players') || '[]');
+    if (!data.includes(name)) {
+      data.push(name);
+      localStorage.setItem('darts-players', JSON.stringify(data));
+    }
+  }
+
+  addPlayerBtn.addEventListener('click', () => {
+    const name = newPlayerInput.value.trim();
+    if (name) {
+      savePlayer(name);
+      newPlayerInput.value = '';
+      loadPlayers();
+    }
+  });
+
+  let guestCount = 1;
+  addGuestBtn.addEventListener('click', () => {
+    const arr = playersInput.value ? playersInput.value.split(',') : [];
+    arr.push('Gast ' + guestCount++);
+    playersInput.value = arr.join(',');
+  });
+
+  let gamePlayers = [];
+  let scores = [];
+  let currentPlayer = 0;
+  let throwsLeft = 3;
+  let multiplier = 1;
+
+  function setupKeypad() {
+    throwArea.innerHTML = '';
+    const numbers = Array.from({ length: 21 }, (_, i) => i);
+    numbers.push(25, 50);
+    numbers.forEach(n => {
+      const btn = document.createElement('button');
+      btn.className = 'btn btn-outline-secondary m-1';
+      btn.textContent = n;
+      btn.addEventListener('click', () => registerThrow(n));
+      throwArea.appendChild(btn);
+    });
+    const multiDiv = document.createElement('div');
+    multiDiv.className = 'mt-2';
+    const dBtn = document.createElement('button');
+    dBtn.className = 'btn btn-secondary me-2';
+    dBtn.textContent = 'Double';
+    const tBtn = document.createElement('button');
+    tBtn.className = 'btn btn-secondary';
+    tBtn.textContent = 'Triple';
+    dBtn.addEventListener('click', () => { multiplier = multiplier === 2 ? 1 : 2; updateMulti(); });
+    tBtn.addEventListener('click', () => { multiplier = multiplier === 3 ? 1 : 3; updateMulti(); });
+    multiDiv.appendChild(dBtn);
+    multiDiv.appendChild(tBtn);
+    throwArea.appendChild(multiDiv);
+
+    function updateMulti() {
+      dBtn.classList.toggle('active', multiplier === 2);
+      tBtn.classList.toggle('active', multiplier === 3);
+    }
+  }
+
+  function registerThrow(n) {
+    scores[currentPlayer] -= n * multiplier;
+    updateScoreboard();
+    throwsLeft--;
+    if (throwsLeft === 0) {
+      nextPlayerBtn.classList.remove('hidden');
+    }
+  }
+
+  function updateScoreboard() {
+    scoreboard.innerHTML = '';
+    gamePlayers.forEach((p, i) => {
+      const div = document.createElement('div');
+      div.className = 'd-flex justify-content-between';
+      div.innerHTML = `<strong>${p}</strong><span>${scores[i]}</span>`;
+      if (i === currentPlayer) div.classList.add('fw-bold');
+      scoreboard.appendChild(div);
+    });
+  }
+
+  nextPlayerBtn.addEventListener('click', () => {
+    throwsLeft = 3;
+    multiplier = 1;
+    nextPlayerBtn.classList.add('hidden');
+    currentPlayer = (currentPlayer + 1) % gamePlayers.length;
+    updateScoreboard();
+  });
+
+  function startGame() {
+    const names = playersInput.value.split(',').map(s => s.trim()).filter(Boolean);
+    if (!names.length) return;
+    gamePlayers = names;
+    scores = names.map(() => parseInt(modeSelect.value, 10));
+    currentPlayer = 0;
+    throwsLeft = 3;
+    multiplier = 1;
+    updateScoreboard();
+    setupKeypad();
+    saveStats(names);
+    showSection('game');
+  }
+
+  startBtn.addEventListener('click', startGame);
 
   function loadStats() {
     const stats = JSON.parse(localStorage.getItem('darts-stats') || '{}');
     statsContent.innerHTML = Object.keys(stats).length ? '' : 'Keine Daten';
     for (const [name, data] of Object.entries(stats)) {
       const div = document.createElement('div');
-      div.textContent = `${name}: ${data.games} Spiele`; // simple display
+      div.textContent = `${name}: ${data.games} Spiele`;
       statsContent.appendChild(div);
     }
   }
@@ -38,26 +179,9 @@
     localStorage.setItem('darts-stats', JSON.stringify(stats));
   }
 
-  function startGame() {
-    const players = playersInput.value.split(',').map(p => p.trim()).filter(Boolean);
-    if (!players.length) return;
-    saveStats(players);
-    loadStats();
-
-    scoreboard.innerHTML = '';
-    players.forEach(name => {
-      const row = document.createElement('div');
-      row.className = 'player d-flex justify-content-between align-items-center';
-      row.innerHTML = `<span>${name}</span><input type="number" class="form-control w-auto" value="0">`;
-      scoreboard.appendChild(row);
-    });
-    gameSection.classList.remove('hidden');
-  }
-
-  startBtn.addEventListener('click', startGame);
   loadStats();
+  loadPlayers();
 
-  // PWA install popup and service worker
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('service-worker.js');
   }

--- a/index.html
+++ b/index.html
@@ -14,36 +14,82 @@
   </header>
 
   <main class="container py-3">
-    <section id="new-game" class="mb-4">
-      <h2>Neues Spiel starten</h2>
-      <label for="mode" class="form-label">Spielmodus:</label>
-      <select id="mode" class="form-select">
-        <option value="301">301</option>
-        <option value="501" selected>501</option>
-        <option value="tannenbaum">Tannenbaum</option>
-      </select>
-      <div class="form-check my-2">
+    <section id="home">
+      <button id="btn-new-game" class="btn btn-primary w-100 mb-2">Neues Spiel starten</button>
+      <button id="btn-stats" class="btn btn-primary w-100 mb-2">Statistiken</button>
+      <button id="btn-players" class="btn btn-primary w-100 mb-2">Spieler</button>
+      <button id="btn-rules" class="btn btn-primary w-100">Regeln</button>
+    </section>
+
+    <section id="new-game" class="hidden">
+      <h2>Neues Spiel</h2>
+      <div class="mb-2">
+        <label for="mode" class="form-label">Spielmodus:</label>
+        <select id="mode" class="form-select">
+          <option value="301">301</option>
+          <option value="501" selected>501</option>
+          <option value="tannenbaum">Tannenbaum</option>
+        </select>
+      </div>
+      <div class="mb-2">
+        <label for="rounds" class="form-label">Runden:</label>
+        <input type="number" id="rounds" class="form-control" value="10" min="1">
+      </div>
+      <div class="form-check mb-1">
+        <input class="form-check-input" type="checkbox" id="double-in">
+        <label class="form-check-label" for="double-in">Double In</label>
+      </div>
+      <div class="form-check mb-2">
         <input class="form-check-input" type="checkbox" id="double-out">
         <label class="form-check-label" for="double-out">Double Out</label>
       </div>
-      <label for="players" class="form-label">Spieler (durch Komma getrennt):</label>
-      <input type="text" id="players" class="form-control mb-2" placeholder="z.B. Alice,Bob">
-      <button id="start-game" class="btn btn-primary">Start</button>
+      <div class="mb-2">
+        <label for="players" class="form-label">Spieler (Komma getrennt):</label>
+        <input type="text" id="players" class="form-control" placeholder="z.B. Alice,Bob">
+      </div>
+      <button id="add-guest" class="btn btn-secondary mb-2">Gast hinzuf&uuml;gen</button>
+      <div>
+        <button id="start-game" class="btn btn-success">Spiel starten</button>
+        <button class="btn btn-link" id="back-home-from-new">Zur&uuml;ck</button>
+      </div>
     </section>
 
     <section id="game" class="hidden">
-      <h2>Spiel</h2>
-      <div id="scoreboard" class="mb-4"></div>
+      <div class="d-flex justify-content-between align-items-center mb-2">
+        <h2 class="m-0">Aktives Spiel</h2>
+        <button class="btn btn-link" id="back-home-from-game">Beenden</button>
+      </div>
+      <div id="scoreboard" class="mb-3"></div>
+      <div id="throw-area" class="mb-3"></div>
+      <button id="next-player" class="btn btn-primary hidden">N&auml;chster Spieler</button>
     </section>
 
-    <section id="stats">
-      <h2>Statistiken</h2>
-      <div id="stats-content"></div>
+    <section id="stats" class="hidden">
+      <div class="d-flex justify-content-between align-items-center">
+        <h2 class="m-0">Statistiken</h2>
+        <button class="btn btn-link" id="back-home-from-stats">Zur&uuml;ck</button>
+      </div>
+      <div id="stats-content" class="mt-2"></div>
     </section>
 
-    <section id="rules">
-      <h2>Regeln</h2>
-      <p id="rules-text">Waehle einen Spielmodus, um die Regeln zu sehen.</p>
+    <section id="players" class="hidden">
+      <div class="d-flex justify-content-between align-items-center">
+        <h2 class="m-0">Spieler</h2>
+        <button class="btn btn-link" id="back-home-from-players">Zur&uuml;ck</button>
+      </div>
+      <div id="players-list" class="mt-2"></div>
+      <div class="input-group mt-2">
+        <input type="text" id="new-player" class="form-control" placeholder="Name">
+        <button id="add-player" class="btn btn-primary">Hinzuf&uuml;gen</button>
+      </div>
+    </section>
+
+    <section id="rules" class="hidden">
+      <div class="d-flex justify-content-between align-items-center">
+        <h2 class="m-0">Regeln</h2>
+        <button class="btn btn-link" id="back-home-from-rules">Zur&uuml;ck</button>
+      </div>
+      <p id="rules-text" class="mt-2">Waehle einen Spielmodus, um die Regeln zu sehen.</p>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- implement home navigation with buttons to switch sections
- add forms for new game setup and player management
- implement active game scoreboard with keypad for entering scores
- store basic game statistics in localStorage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866792946088324afa67a8726de0ea5