### PR TITLE
Add theme settings and restructure src

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Dieses Projekt ist eine einfache Progressive Web App (PWA), mit der Darts-Spiele
 - **Speicherung in localStorage**: Saemtliche Daten werden im Browser gespeichert.
 - **App-Installation**: Die Anwendung kann als PWA installiert werden.
 - **Responsive Design**: Dank eingebundenem Bootstrap passt sich die Oberflaeche an unterschiedliche Bildschirmgroessen an.
+- **Einstellungsseite**: In den Einstellungen kann zwischen mehreren Farbthemes gewechselt werden. Standardmaeßig orientiert sich die App am System-Theme.
 
 ## Nutzung
 
@@ -30,8 +31,10 @@ Diese Anwendung kann direkt ueber GitHub Pages veroeffentlicht werden. Im Reposi
 ## Dateien
 
 - `index.html` – Einstiegspunkt der WebApp
-- `styles.css` – Grundlegendes Styling; Bootstrap wird per CDN eingebunden
-- `app.js` – Logik zum Starten von Spielen und Speichern der Daten
+- `src/index.js` – Einstiegspunkt fuer React und Themeverwaltung
+- `src/App.js` – Hauptlogik zum Starten von Spielen und Speichern der Daten
+- `src/styles.css` – Grundlegendes Styling; Bootstrap wird per CDN eingebunden und per Themes angepasst
+- `src/themes.json` – Definiert die verfuegbaren Farbthemes
 - `manifest.json` – Einstellungen fuer die PWA-Installation
 - `service-worker.js` – Offline-Unterstuetzung
 - Icons sind direkt im `manifest.json` als Base64-Daten eingebettet

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Darts WebApp</title>
   <link rel="manifest" href="manifest.json">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="src/styles.css">
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
@@ -21,6 +21,6 @@
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script type="text/babel" src="app.js"></script>
+  <script type="text/babel" src="src/index.js"></script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -4,8 +4,10 @@ self.addEventListener('install', event => {
       return cache.addAll([
         './',
         './index.html',
-        './styles.css',
-        './app.js'
+        './src/styles.css',
+        './src/index.js',
+        './src/App.js',
+        './src/themes.json'
       ]);
     })
   );

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 const { useState, useEffect } = React;
 
-function App() {
+function App({ setThemeName, themes }) {
   const [view, setView] = useState('home');
   const [players, setPlayers] = useState(() => JSON.parse(localStorage.getItem('darts-players') || '[]'));
   const [stats, setStats] = useState(() => JSON.parse(localStorage.getItem('darts-stats') || '{}'));
@@ -95,7 +95,8 @@ function App() {
           <button className="btn btn-primary w-100 mb-2" onClick={() => { setNewGamePlayers([]); setView('newGame'); }}>Neues Spiel starten</button>
           <button className="btn btn-primary w-100 mb-2" onClick={() => setView('stats')}>Statistiken</button>
           <button className="btn btn-primary w-100 mb-2" onClick={() => setView('players')}>Spieler</button>
-          <button className="btn btn-primary w-100" onClick={() => setView('rules')}>Regeln</button>
+          <button className="btn btn-primary w-100 mb-2" onClick={() => setView('rules')}>Regeln</button>
+          <button className="btn btn-primary w-100" onClick={() => setView('settings')}>Einstellungen</button>
         </section>
       )}
 
@@ -214,6 +215,22 @@ function App() {
         </section>
       )}
 
+      {view === 'settings' && (
+        <section id="settings">
+          <div className="d-flex justify-content-between align-items-center">
+            <h2 className="m-0">Einstellungen</h2>
+            <button className="btn btn-link back-btn" onClick={() => setView('home')}>&#x2190;</button>
+          </div>
+          <div className="mt-2">
+            {Object.keys(themes).map(name => (
+              <button key={name} className="btn btn-primary me-2 mb-2" onClick={() => setThemeName(name)}>
+                {name}
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+
       {/* Player Modal */}
       {playerModalShow && (
         <div className="modal d-block" tabIndex="-1">
@@ -272,7 +289,4 @@ function App() {
   );
 }
 
-ReactDOM.createRoot(document.getElementById('root')).render(<App />);
-if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('service-worker.js');
-}
+export default App;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,37 @@
+const { useState, useEffect } = React;
+
+function applyTheme(theme) {
+  if (!theme) return;
+  for (const [key, val] of Object.entries(theme)) {
+    document.documentElement.style.setProperty(key, val);
+  }
+}
+
+function AppWrapper() {
+  const [themes, setThemes] = useState({});
+  const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const [themeName, setThemeName] = useState(
+    localStorage.getItem('theme') || (systemDark ? 'dark' : 'light')
+  );
+
+  useEffect(() => {
+    fetch('src/themes.json')
+      .then(res => res.json())
+      .then(data => setThemes(data));
+  }, []);
+
+  useEffect(() => {
+    if (themes[themeName]) {
+      applyTheme(themes[themeName]);
+      localStorage.setItem('theme', themeName);
+    }
+  }, [themes, themeName]);
+
+  return <App setThemeName={setThemeName} themes={themes} />;
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<AppWrapper />);
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('service-worker.js');
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,14 +1,28 @@
+:root {
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --primary-color: #0d6efd;
+}
+
 body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 0;
   line-height: 1.5;
+  background-color: var(--bg-color);
+  color: var(--text-color);
 }
+
 header {
-  background-color: #333;
+  background-color: var(--primary-color);
   color: white;
   padding: 1rem;
   text-align: center;
+}
+
+.btn-primary {
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
 }
 main {
   padding: 1rem;

--- a/src/themes.json
+++ b/src/themes.json
@@ -1,0 +1,22 @@
+{
+  "light": {
+    "--bg-color": "#ffffff",
+    "--text-color": "#000000",
+    "--primary-color": "#0d6efd"
+  },
+  "dark": {
+    "--bg-color": "#121212",
+    "--text-color": "#ffffff",
+    "--primary-color": "#bb86fc"
+  },
+  "blue": {
+    "--bg-color": "#e7f1ff",
+    "--text-color": "#0d3b66",
+    "--primary-color": "#1e90ff"
+  },
+  "green": {
+    "--bg-color": "#e6f4ea",
+    "--text-color": "#1b4332",
+    "--primary-color": "#2d6a4f"
+  }
+}


### PR DESCRIPTION
## Summary
- organize code in a new `src` folder similar to modern React projects
- add `index.js` entry point and remove direct rendering from `App.js`
- support multiple color themes via new `themes.json`
- provide a settings view to switch themes and follow the system theme by default
- update service worker and documentation

## Testing
- `npm -v`
- `node -e "console.log('node works')"`
- `node -e "const fs=require('fs');console.log(Object.keys(JSON.parse(fs.readFileSync('src/themes.json','utf8'))))"`

------
https://chatgpt.com/codex/tasks/task_e_686681c9642c83249007937f1f20f9a2